### PR TITLE
.mat to .pt as a slurm job and separates labels from data in submission

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -4,7 +4,7 @@ logs_dir: "./logs"  # Relative to repository root
 
 conversion:
   script_path: ""
-  default_args: "--inputs {inputs} --output {output_dir}"
+  default_args: "--inputs {inputs} --labels {labels} --output {output_dir}"
 
 training:
   script_path: ""


### PR DESCRIPTION
… conversion script as a Slurm job. I've also added the ability to include label files in the conversion process.

Here's a summary of the changes:
- The user interface now has options for adding and displaying label files, as well as a checkbox to enable Slurm submission.
- The conversion process has been updated to handle label files and to submit the job to Slurm when requested.
- The default configuration has been updated to include a placeholder for labels.