### PR TITLE
feat: Use template for Slurm script generation

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -2,13 +2,14 @@ workspace_dir: .
 jobs_dir: ./jobs
 logs_dir: ./logs
 conversion:
-  script_path: ''
+  script_path: src/utils/NCandaToTorchGraphDataGUITest.py
   default_args: --inputs {inputs} --labels {labels} --output {output_dir}
 training:
   script_path: ''
   default_args: --data {dataset_dir} --model {model}
 slurm:
   use_slurm_by_default: false
+  template_path: src/utils/MakeTorchGraphData.sh
   job_name: MakeTorchGraphData
   output: /isilon/datalake/lcbn_research/final/beach/JonathanP/MakeTorchGraphDataOutput.txt
   error: /isilon/datalake/lcbn_research/final/beach/JonathanP/MakeTorchGraphDataError.txt

--- a/src/utils/slurm.py
+++ b/src/utils/slurm.py
@@ -1,70 +1,82 @@
 import os
 import datetime as _dt
 import subprocess
-from typing import Dict, Any
-
-
-def _make_sbatch_header(cfg: Dict[str, Any]) -> str:
-    slurm = cfg.get("slurm", {})
-    lines = [
-        "#!/bin/bash -l",
-        f"#SBATCH --job-name={slurm.get('job_name', 'MakeTorchGraphData')}",
-        f"#SBATCH --output={slurm.get('output', '/isilon/datalake/lcbn_research/final/beach/JonathanP/MakeTorchGraphDataOutput.txt')}",
-        f"#SBATCH --error={slurm.get('error', '/isilon/datalake/lcbn_research/final/beach/JonathanP/MakeTorchGraphDataError.txt')}",
-        "#SBATCH --nodes 1",
-    ]
-    if slurm.get("partition"): lines.append(f"#SBATCH -p {slurm['partition']}")
-    if slurm.get("gpus", 0): lines.append(f"#SBATCH --gpus {int(slurm['gpus'])}")
-    if slurm.get("mem"): lines.append(f"#SBATCH --mem {slurm['mem']}")
-    if slurm.get("time"): lines.append(f"#SBATCH --time {slurm['time']}")
-    if slurm.get("account"): lines.append(f"#SBATCH --account={slurm['account']}")
-    if slurm.get("qos"): lines.append(f"#SBATCH --qos={slurm['qos']}")
-    if slurm.get("additional"): lines.append(slurm["additional"])  # raw extra SBATCH lines
-    lines.append("")
-    if slurm.get("env_activation"): lines.append(slurm["env_activation"])  # e.g., conda activate
-    lines.append("")
-    return "\n".join(lines)
+from typing import Dict, Any, List
+import re
 
 
 def write_job_script(command: str, cfg: Dict[str, Any]) -> str:
-    jobs_dir = cfg["jobs_dir"]
-    os.makedirs(jobs_dir, exist_ok=True)
-    stamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
-    job_name = cfg.get("slurm", {}).get("job_name", "gnn_job")
-    path = os.path.join(jobs_dir, f"{job_name}_{stamp}.sh")
-    content = _make_sbatch_header(cfg) + "\n" + command + "\n"
-    with open(path, "w", encoding="utf-8") as f:
-        f.write(content)
-    os.chmod(path, 0o750)
-    return path
-
-
-def write_job_script_from_template(command: str, template_path: str, cfg: Dict[str, Any]) -> str:
     """
-    Creates a SLURM job script from a template file, replacing the python command.
+    Creates a SLURM job script from a template file, replacing SBATCH directives
+    and the python command based on the provided configuration.
     """
+    slurm_cfg = cfg.get("slurm", {})
+    template_path = slurm_cfg.get("template_path")
+    if not template_path or not os.path.exists(template_path):
+        raise FileNotFoundError(f"SLURM template script not found at: {template_path}")
+
     with open(template_path, "r") as f:
         template_lines = f.readlines()
 
-    # Find the python execution line to replace it, ignoring commented lines
-    command_line_idx = -1
-    for i, line in enumerate(template_lines):
-        if "python" in line and not line.strip().startswith("#"):
-            command_line_idx = i
-            break
+    # Mapping from config key to SBATCH directive
+    sbatch_map = {
+        "job_name": "--job-name",
+        "output": "--output",
+        "error": "--error",
+        "partition": "-p",
+        "gpus": "--gpus",
+        "mem": "--mem",
+        "time": "--time",
+        "account": "--account",
+        "qos": "--qos",
+    }
 
-    if command_line_idx != -1:
-        template_lines[command_line_idx] = command + "\n"
-    else:
-        # If no python command found, append the new command
-        template_lines.append("\n" + command + "\n")
+    new_lines: List[str] = []
+    python_cmd_replaced = False
 
-    content = "".join(template_lines)
+    for line in template_lines:
+        stripped_line = line.strip()
+        if stripped_line.startswith("#SBATCH"):
+            found_match = False
+            for cfg_key, sbatch_key in sbatch_map.items():
+                # Regex to match SBATCH directive, accommodating both space and '=' separators
+                pattern = re.compile(rf"(#SBATCH\s+{re.escape(sbatch_key)})(?:[=\s])(.*)")
+                match = pattern.match(stripped_line)
+                if match:
+                    if cfg_key in slurm_cfg:
+                        new_value = slurm_cfg[cfg_key]
+                        new_lines.append(f"{match.group(1)} {new_value}\n")
+                        found_match = True
+                        break
+            if not found_match:
+                new_lines.append(line)  # Keep original line if no config override
+        elif "python" in stripped_line and not stripped_line.startswith("#"):
+            # Replace the python command execution line
+            # We assume the command includes 'srun' or similar, which is replaced entirely.
+            new_lines.append(f"srun {command}\n")
+            python_cmd_replaced = True
+        else:
+            new_lines.append(line)
 
-    jobs_dir = cfg["jobs_dir"]
+    # If the python command was not found to be replaced, append it.
+    if not python_cmd_replaced:
+        new_lines.append(f"\nsrun {command}\n")
+
+    # Add env activation if specified
+    if slurm_cfg.get("env_activation"):
+        # Insert before the command
+        for i, line in enumerate(new_lines):
+            if "srun" in line:
+                new_lines.insert(i, f'{slurm_cfg["env_activation"]}\n')
+                break
+
+    content = "".join(new_lines)
+
+    jobs_dir = cfg.get("jobs_dir", "./jobs")
     os.makedirs(jobs_dir, exist_ok=True)
     stamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
-    path = os.path.join(jobs_dir, f"gnn_job_{stamp}.sh")
+    job_name = slurm_cfg.get("job_name", "gnn_job")
+    path = os.path.join(jobs_dir, f"{job_name}_{stamp}.sh")
 
     with open(path, "w", encoding="utf-8") as f:
         f.write(content)


### PR DESCRIPTION
This commit refactors the Slurm job script generation to use a template-based approach as requested by the user.

The `write_job_script` function now reads a template file, replaces #SBATCH directives and the python command based on the UI configuration, and saves a new job script.

The UI and default configuration have been updated to support the new options, including job name, output/error paths, and a dropdown for the partition.

This addresses the user's feedback to modify an existing script template instead of generating a new script from scratch.