### PR TITLE
Fix slurm submission

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -247,12 +247,31 @@ class MainWindow(QMainWindow):
 
         if self.use_slurm_conversion.isChecked():
             slurm_config = self.config.get("slurm_conversion", {})
-            script_path = update_slurm_script("src/utils/MakeTorchGraphData.sh", command, slurm_config)
+            template_path = "src/utils/MakeTorchGraphData.sh"
+
+            # Create a temporary, unique job script to prevent race conditions
+            jobs_dir = self.config.get("jobs_dir", "jobs")
+            os.makedirs(jobs_dir, exist_ok=True)
+            job_filename = f"conversion_job_{datetime.now().strftime('%Y%m%d-%H%M%S')}.sh"
+            job_script_path = os.path.join(jobs_dir, job_filename)
+
+            try:
+                # Copy template content to the new job script
+                with open(template_path, 'r') as f_template:
+                    with open(job_script_path, 'w') as f_job:
+                        f_job.write(f_template.read())
+            except FileNotFoundError:
+                self._append_console(f"SLURM template not found at: {template_path}\\n")
+                return
+
+            # Update the new job script with the command and config
+            script_path = update_slurm_script(job_script_path, command, slurm_config)
             result = submit_job(script_path)
+
             if result.returncode == 0:
-                self._append_console(f"Submitted job: {result.stdout}")
+                self._append_console(f"Submitted conversion job script: {script_path}\\nJob ID: {result.stdout}")
             else:
-                self._append_console(f"SLURM submit failed: {result.stderr}")
+                self._append_console(f"SLURM submit failed for script {script_path}:\\n{result.stderr}")
         else:
             command = f"{_detect_interpreter(script)} {args_filled}".strip()
             self._start_command(command)

--- a/src/utils/MakeTorchGraphData.sh
+++ b/src/utils/MakeTorchGraphData.sh
@@ -14,5 +14,5 @@ module load cuda-toolkit/11.8.0
 
 conda activate NeuroGraph
 
-cd /isilon/datalake/lcbn_research/final/beach/JonathanP
-srun python MakeTorchGraphData.py
+# The command will be inserted below by the GUI application
+# <<< COMMAND HERE >>>

--- a/src/utils/gnn_training_template.sh
+++ b/src/utils/gnn_training_template.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -l
+#SBATCH --job-name GNNTraining
+#SBATCH --output gnn_training_output.txt
+#SBATCH --error gnn_training_error.txt
+#SBATCH --nodes 1
+#SBATCH -p gpu-h100
+#SBATCH --gpus 1
+#SBATCH --mem 100G
+#SBATCH --time 1:00:00
+
+# Placeholder for environment setup, if needed
+# e.g., module load cuda-toolkit/11.8.0
+# e.g., conda activate my-env
+
+# The command will be inserted below by the GUI application
+# <<< COMMAND HERE >>>


### PR DESCRIPTION
Make SLURM submission robust for data conversion step

This commit applies the same unique-script-per-job logic from the training step to the data conversion step. This resolves a potential race condition that could occur if multiple conversion jobs were submitted in quick succession.

Changes include:

1.  **Updating the conversion template:** The script `src/utils/MakeTorchGraphData.sh` is modified to use the `# <<< COMMAND HERE >>>` placeholder, replacing the previous hardcoded command. This makes it consistent with the training template.

2.  **Refactoring the conversion logic:** The `_run_conversion` method in `src/ui/main_window.py` is updated to generate a unique, timestamped job script in the `jobs/` directory for each conversion. This prevents jobs from interfering with each other and improves the reliability of the application.