### PR TITLE
feat: Extract filename from dataset path in GUI

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -210,7 +210,7 @@ class MainWindow(QMainWindow):
             self, "Select dataset file", filter="PyTorch data (*.pt);;All files (*)"
         )
         if path:
-            self.dataset_file_input.setText(path)
+            self.dataset_file_input.setText(os.path.basename(path))
 
     # ------------- Command builders -------------
     def _format_args(self, template: str, mapping: Dict[str, str]) -> str:


### PR DESCRIPTION
The GUI's dataset file selector now displays only the filename (e.g., "NCandaData500_cddr15a_5pct.pt") instead of the full file path.

This was accomplished by using `os.path.basename()` to extract the filename from the path provided by the file dialog.