### PR TITLE
Fix: Correctly format srun command in generated sbatch script

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -298,7 +298,11 @@ class MainWindow(QMainWindow):
         if self.use_slurm.isChecked():
             # TODO: Make the python script name configurable
             python_script = "main_NCanda.py"
-            command = f"python {python_script} {args_filled}".strip()
+
+            # Reformat args for multiline sbatch script
+            multiline_args = re.sub(r'\s+(--)', r' \\\n  \1', args_filled)
+            command = f"python {python_script} {multiline_args}".strip()
+
             slurm_config = self.config.get("slurm_training", {})
             script_path = update_slurm_script(script, command, slurm_config)
             result = submit_job(script_path)


### PR DESCRIPTION
The srun command in the dynamically generated sbatch script was being written as a single line. This broke the shell's multi-line command execution because it was missing the trailing backslashes needed for line continuation.

This change fixes the issue by reformatting the command's arguments with the necessary backslashes and newlines before they are written to the sbatch script file. This ensures the generated script is syntactically correct.

The formatting logic has been added to `src/ui/main_window.py`, which is where the command arguments are constructed before being passed to the script update utility. This approach was confirmed by the user to be the correct place for the fix.