### PR TITLE
Fix: Correctly format srun command in generated sbatch script

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -300,7 +300,12 @@ class MainWindow(QMainWindow):
             python_script = "main_NCanda.py"
 
             # Reformat args for multiline sbatch script
-            multiline_args = re.sub(r'\s+(--)', r' \\\n  \1', args_filled)
+            args_parts = [p.strip() for p in args_filled.split('--') if p.strip()]
+            if args_parts:
+                # Prepend '--' to each part since split removed it, then join with backslash-newline
+                multiline_args = " \\\n  ".join([f"--{p}" for p in args_parts])
+            else:
+                multiline_args = ""
             command = f"python {python_script} {multiline_args}".strip()
 
             slurm_config = self.config.get("slurm_training", {})


### PR DESCRIPTION
The srun command in the dynamically generated sbatch script was being written as a single line. This broke the shell's multi-line command execution because it was missing the trailing backslashes needed for line continuation.

This change fixes the issue by reformatting the command's arguments with the necessary backslashes and newlines before they are written to the sbatch script file. This ensures the generated script is syntactically correct.

The formatting logic has been added to `src/ui/main_window.py`, which is where the command arguments are constructed. This version uses a more robust method of splitting the argument string by the '--' delimiter to avoid issues with complex argument values.