### PR TITLE
Fix srun command formatting for multiline arguments

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -298,16 +298,7 @@ class MainWindow(QMainWindow):
         if self.use_slurm.isChecked():
             # TODO: Make the python script name configurable
             python_script = "main_NCanda.py"
-
-            # Reformat args for multiline sbatch script
-            args_parts = [p.strip() for p in args_filled.split('--') if p.strip()]
-            if args_parts:
-                # Prepend '--' to each part since split removed it, then join with backslash-newline
-                multiline_args = " \\\n  ".join([f"--{p}" for p in args_parts])
-            else:
-                multiline_args = ""
-            command = f"python {python_script} {multiline_args}".strip()
-
+            command = f"python {python_script} {args_filled}".strip()
             slurm_config = self.config.get("slurm_training", {})
             script_path = update_slurm_script(script, command, slurm_config)
             result = submit_job(script_path)


### PR DESCRIPTION
The `srun` command in the generated SLURM script was not correctly formatted for multiline arguments, causing the script to fail.

This commit fixes the issue by:
- Centralizing the command formatting logic in `src/utils/slurm.py`.
- Using `shlex.split` to robustly parse the command and its arguments.
- Correctly adding backslashes for line continuation in the SLURM script.