### PR TITLE
This commit introduces a new input field in the PyQt GUI to specify t…

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -72,6 +72,13 @@ class MainWindow(QMainWindow):
         btn_out.clicked.connect(self._pick_out_dir)
         add_files_row.addWidget(btn_out)
 
+        conv_opts_row = QHBoxLayout()
+        root.addLayout(conv_opts_row)
+        conv_opts_row.addWidget(QLabel("ROIs:"))
+        self.num_rois = QLineEdit("500")
+        conv_opts_row.addWidget(self.num_rois)
+        conv_opts_row.addStretch(1)
+
         files_row = QHBoxLayout()
         root.addLayout(files_row)
 
@@ -248,7 +255,8 @@ class MainWindow(QMainWindow):
             _detect_interpreter(script),
             "--inputs", *[f'"{p}"' for p in input_files],
             "--labels", f'"{label_file}"',
-            "--output_dir", f'"{out_dir}"'
+            "--output_dir", f'"{out_dir}"',
+            "--ROIs", self.num_rois.text().strip()
         ]
 
         command = " ".join(command_parts)


### PR DESCRIPTION
…he number of Regions of Interest (ROIs) for the data conversion process.

The following changes have been made:
- In `src/ui/main_window.py`, a `QLineEdit` has been added to the GUI, allowing users to input the number of ROIs. The default value is set to 500.
- The `_run_conversion` method in `main_window.py` has been updated to read the value from this new input field and append it to the command-line arguments as `--ROIs` when calling the conversion script.

This ensures that the user-specified number of ROIs is passed to the `NCandaToTorchGraphDataGUITest.py` script. The mechanism for passing the command to the `MakeTorchGraphData.sh` script via the `update_slurm_script` function remains the same, as the function dynamically inserts the entire generated command into the shell script template.