### PR TITLE
Refactor: Remove unused variables in conversion logic

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -268,10 +268,8 @@ class MainWindow(QMainWindow):
         os.makedirs(out_dir, exist_ok=True)
 
         input_files: List[str] = [self.files_list.item(i).text() for i in range(self.files_list.count())]
-        inputs_str = " ".join(f'"{p}"' for p in input_files)
 
         label_files: List[str] = [self.labels_list.item(i).text() for i in range(self.labels_list.count())]
-        labels_str = " ".join(f'"{p}"' for p in label_files)
 
         # Ensure there's at least one label file, and take the first one.
         if not label_files:


### PR DESCRIPTION
In the `_run_conversion` method in `src/ui/main_window.py`, the variables `inputs_str` and `labels_str` were created but not used. This was likely a remnant of a previous implementation and could cause confusion about how the selected files are passed to the conversion script.

This change removes these unused variables to make the code cleaner and the logic clearer. The application's functionality of passing file paths as command-line arguments remains unchanged.