### PR TITLE
feat: Update GUI defaults and labels

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -23,6 +23,8 @@ def _detect_interpreter(script_path: str) -> str:
 
 
 def _format_label(text: str) -> str:
+    if text == "--early_stopping":
+        return "Early Stopping (epochs)"
     return text.replace("--", "").replace("_", " ").title()
 
 

--- a/src/ui/slurm_config_widget.py
+++ b/src/ui/slurm_config_widget.py
@@ -37,12 +37,12 @@ class SlurmConfigWidget(QWidget):
             self.config[self.config_key] = {}
         slurm_config = self.config[self.config_key]
         self.job_name.setText(slurm_config.get("job_name", "MakeTorchGraphData"))
-        self.output.setText(slurm_config.get("output", ""))
-        self.error.setText(slurm_config.get("error", ""))
+        self.output.setText(slurm_config.get("output", "./logs/train_out.txt"))
+        self.error.setText(slurm_config.get("error", "./logs/train_err.txt"))
         self.partition.setCurrentText(slurm_config.get("partition", "gpu-h100"))
         self.gpus.setValue(int(slurm_config.get("gpus", 2)))
         self.mem.setText(slurm_config.get("mem", "700000M"))
-        self.time.setText(slurm_config.get("time", "24:00:00"))
+        self.time.setText(slurm_config.get("time", "04:00:00"))
         self.additional.setText(slurm_config.get("additional", ""))
         self.env_activation.setText(slurm_config.get("env_activation", ""))
 


### PR DESCRIPTION
This commit introduces several updates to the GUI's default settings to improve user experience:

- The 'Early Stopping' label in the training arguments is now 'Early Stopping (epochs)' to clarify that the input should be the number of epochs.
- The default output file in the SLURM configuration is set to `./logs/train_out.txt`.
- The default error file in the SLURM configuration is set to `./logs/train_err.txt`.
- The default time in the SLURM configuration is changed from 24:00:00 to 04:00:00.