### PR TITLE
feat: Update default SLURM job name for training

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -134,7 +134,9 @@ class MainWindow(QMainWindow):
         # Slurm config for conversion
         self.slurm_conversion_group = QGroupBox("SLURM Configuration for Conversion")
         slurm_conversion_layout = QVBoxLayout(self.slurm_conversion_group)
-        self.slurm_conversion_config_widget = SlurmConfigWidget(self.config, "slurm_conversion")
+        self.slurm_conversion_config_widget = SlurmConfigWidget(
+            self.config, "slurm_conversion", default_job_name="MakeTorchGraphData"
+        )
         slurm_conversion_layout.addWidget(self.slurm_conversion_config_widget)
         root.addWidget(self.slurm_conversion_group)
         self.slurm_conversion_group.setVisible(False)
@@ -181,7 +183,9 @@ class MainWindow(QMainWindow):
         # Slurm config for training
         self.slurm_training_group = QGroupBox("SLURM Configuration for Training")
         slurm_training_layout = QVBoxLayout(self.slurm_training_group)
-        self.slurm_training_config_widget = SlurmConfigWidget(self.config, "slurm_training")
+        self.slurm_training_config_widget = SlurmConfigWidget(
+            self.config, "slurm_training", default_job_name="LCBN_GNN_Training"
+        )
         slurm_training_layout.addWidget(self.slurm_training_config_widget)
         root.addWidget(self.slurm_training_group)
         self.slurm_training_group.setVisible(False)

--- a/src/ui/slurm_config_widget.py
+++ b/src/ui/slurm_config_widget.py
@@ -1,10 +1,11 @@
 from PyQt5.QtWidgets import QWidget, QLineEdit, QSpinBox, QFormLayout, QLabel, QComboBox
 
 class SlurmConfigWidget(QWidget):
-    def __init__(self, config, config_key="slurm", parent=None):
+    def __init__(self, config, config_key="slurm", default_job_name="MakeTorchGraphData", parent=None):
         super().__init__(parent)
         self.config = config
         self.config_key = config_key
+        self.default_job_name = default_job_name
 
         layout = QFormLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -36,7 +37,7 @@ class SlurmConfigWidget(QWidget):
         if self.config_key not in self.config:
             self.config[self.config_key] = {}
         slurm_config = self.config[self.config_key]
-        self.job_name.setText(slurm_config.get("job_name", "MakeTorchGraphData"))
+        self.job_name.setText(slurm_config.get("job_name", self.default_job_name))
         self.output.setText(slurm_config.get("output", "./logs/train_out.txt"))
         self.error.setText(slurm_config.get("error", "./logs/train_err.txt"))
         self.partition.setCurrentText(slurm_config.get("partition", "gpu-h100"))


### PR DESCRIPTION
The default SLURM job name for the training configuration is updated to "LCBN_GNN_Training" as requested.

To achieve this, the `SlurmConfigWidget` is refactored to accept a `default_job_name` parameter, making it more flexible. The `MainWindow` is then updated to provide the appropriate default job names for both the training and data conversion configurations.