### PR TITLE
Fix: Ensure local execution runs without login shell

### DIFF
--- a/src/utils/process_runner.py
+++ b/src/utils/process_runner.py
@@ -16,7 +16,7 @@ class CommandRunner(QThread):
 
     def run(self) -> None:
         proc = subprocess.Popen([
-            "/usr/bin/bash", "-lc", self.command
+            "/usr/bin/bash", "-c", self.command
         ], cwd=self.working_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=self.env, bufsize=1)
         assert proc.stdout is not None
         for line in proc.stdout:


### PR DESCRIPTION
Modified `src/utils/process_runner.py` to remove the `-l` flag from the `subprocess.Popen` call. This prevents the shell from running as a login shell, which could source user-specific login scripts that might unintentionally redirect commands to a SLURM scheduler.

This change ensures that when the 'Submit with SLURM' checkbox is unchecked, the command is executed directly in a standard local shell, providing a more predictable and isolated execution environment.