### PR TITLE
feat: Run conversion in NeuroGraph conda env

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -363,7 +363,8 @@ class MainWindow(QMainWindow):
             else:
                 self._append_console(f"SLURM submit failed: {result.stderr}")
         else:
-            self._start_command(command)
+            conda_command = f"conda activate NeuroGraph && {command}"
+            self._start_command(conda_command)
 
     def _run_training(self) -> None:
         if self.is_submitting:


### PR DESCRIPTION
When "Submit with SLURM" is not checked, run the data conversion script within the 'NeuroGraph' Conda environment. This ensures that the correct dependencies are available for the script to execute successfully.