### PR TITLE
Fix conda env key

### DIFF
--- a/gnn_gui.py
+++ b/gnn_gui.py
@@ -4,10 +4,18 @@ import os
 # Add src to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), 'src')))
 
+import platform
 from PyQt5.QtWidgets import QApplication
 from ui.main_window import MainWindow
 
 if __name__ == "__main__":
+    if platform.system() != "Windows":
+        xdg_runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+        if not xdg_runtime_dir or not os.access(xdg_runtime_dir, os.W_OK):
+            fallback_dir = os.path.expanduser("~/.gnn_gui_runtime")
+            os.makedirs(fallback_dir, exist_ok=True)
+            os.environ["XDG_RUNTIME_DIR"] = fallback_dir
+
     app = QApplication(sys.argv)
     w = MainWindow()
     w.resize(1000, 700)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -369,7 +369,7 @@ class MainWindow(QMainWindow):
 
         if self.use_slurm_conversion.isChecked():
             slurm_config = self.config.get("slurm_conversion", {})
-            env_name = self.config.get("environment_name", "NeuroGraph")
+            env_name = self.config.get("conda_env", "NeuroGraph")
             script_path = update_slurm_script(
                 "src/utils/MakeTorchGraphData.sh", command, slurm_config, self.config["jobs_dir"], env_name
             )
@@ -379,7 +379,7 @@ class MainWindow(QMainWindow):
             else:
                 self._append_console(f"SLURM submit failed: {result.stderr}")
         else:
-            env_name = self.config.get("environment_name", "NeuroGraph")
+            env_name = self.config.get("conda_env", "NeuroGraph")
             conda_command = f"conda run -n {env_name} {command}"
             self._start_command(conda_command)
 
@@ -442,7 +442,7 @@ class MainWindow(QMainWindow):
                 python_script = "main_NCanda.py"
                 command = f"python {python_script} {args_filled}".strip()
                 slurm_config = self.config.get("slurm_training", {})
-                env_name = self.config.get("environment_name", "NeuroGraph")
+                env_name = self.config.get("conda_env", "NeuroGraph")
                 script_path = update_slurm_script(script, command, slurm_config, self.config["jobs_dir"], env_name)
                 result = submit_job(script_path)
                 if result.returncode == 0:
@@ -451,7 +451,7 @@ class MainWindow(QMainWindow):
                     self._append_console(f"SLURM submit failed: {result.stderr}")
             else:
                 command = f"{_detect_interpreter(script)} {args_filled}".strip()
-                env_name = self.config.get("environment_name", "NeuroGraph")
+                env_name = self.config.get("conda_env", "NeuroGraph")
                 conda_command = f"conda run -n {env_name} {command}"
                 self._start_command(conda_command)
         finally:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -369,7 +369,7 @@ class MainWindow(QMainWindow):
 
         if self.use_slurm_conversion.isChecked():
             slurm_config = self.config.get("slurm_conversion", {})
-            env_name = self.config.get("conda_env", "NeuroGraph")
+            env_name = self.config.get("environment_name", "NeuroGraph")
             script_path = update_slurm_script(
                 "src/utils/MakeTorchGraphData.sh", command, slurm_config, self.config["jobs_dir"], env_name
             )
@@ -379,7 +379,7 @@ class MainWindow(QMainWindow):
             else:
                 self._append_console(f"SLURM submit failed: {result.stderr}")
         else:
-            env_name = self.config.get("conda_env", "NeuroGraph")
+            env_name = self.config.get("environment_name", "NeuroGraph")
             conda_command = f"conda run -n {env_name} {command}"
             self._start_command(conda_command)
 
@@ -442,7 +442,7 @@ class MainWindow(QMainWindow):
                 python_script = "main_NCanda.py"
                 command = f"python {python_script} {args_filled}".strip()
                 slurm_config = self.config.get("slurm_training", {})
-                env_name = self.config.get("conda_env", "NeuroGraph")
+                env_name = self.config.get("environment_name", "NeuroGraph")
                 script_path = update_slurm_script(script, command, slurm_config, self.config["jobs_dir"], env_name)
                 result = submit_job(script_path)
                 if result.returncode == 0:
@@ -451,7 +451,7 @@ class MainWindow(QMainWindow):
                     self._append_console(f"SLURM submit failed: {result.stderr}")
             else:
                 command = f"{_detect_interpreter(script)} {args_filled}".strip()
-                env_name = self.config.get("conda_env", "NeuroGraph")
+                env_name = self.config.get("environment_name", "NeuroGraph")
                 conda_command = f"conda run -n {env_name} {command}"
                 self._start_command(conda_command)
         finally:


### PR DESCRIPTION
This change adds a fallback for the 'XDG_RUNTIME_DIR' to prevent 'QStandardPaths' errors on startup in certain Linux environments. This fix is implemented in 'gnn_gui.py' and only affects non-Windows users.