### PR TITLE
🔒 Fix command injection vulnerability in SLURM command builder

### DIFF
--- a/src/utils/slurm.py
+++ b/src/utils/slurm.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 from typing import Dict, Any
 import re
+import shlex
 from datetime import datetime
 
 def update_slurm_script(template_path: str, command: str, slurm_cfg: Dict[str, Any], jobs_dir: str, conda_env: str) -> str:
@@ -37,15 +38,23 @@ def update_slurm_script(template_path: str, command: str, slurm_cfg: Dict[str, A
                 content = pattern.sub(rf"\1 {new_value}", content)
 
     # The command from the GUI is authoritative.
+    # To prevent command injection, we safely quote the conda environment and the command components.
+    safe_conda_env = shlex.quote(conda_env)
+
+    # Split the command into parts and quote each part safely
+    command_parts = shlex.split(command)
+    safe_command = " ".join(shlex.quote(part) for part in command_parts)
+
     # The srun part is added here to ensure it's always present.
-    new_command_str = f"srun conda run -n {conda_env} {command}"
+    new_command_str = f"srun conda run -n {safe_conda_env} {safe_command}"
 
     # Replace the placeholder with the new command
     content = content.replace("#COMMAND_PLACEHOLDER", new_command_str)
 
     # Replace the conda activation placeholder
-    conda_env = slurm_cfg.get("conda_env", "NeuroGraph")
-    conda_activation_command = f"conda activate {conda_env}"
+    cfg_conda_env = slurm_cfg.get("conda_env", "NeuroGraph")
+    safe_cfg_conda_env = shlex.quote(cfg_conda_env)
+    conda_activation_command = f"conda activate {safe_cfg_conda_env}"
     content = content.replace("#CONDA_ACTIVATION_PLACEHOLDER", conda_activation_command)
 
     # Create a new script in the jobs directory

--- a/tests/utils/test_slurm.py
+++ b/tests/utils/test_slurm.py
@@ -1,0 +1,31 @@
+import os
+import tempfile
+from src.utils.slurm import update_slurm_script
+
+def test_update_slurm_script_injection():
+    # Create a temporary template
+    with tempfile.NamedTemporaryFile("w", delete=False) as f:
+        f.write("#COMMAND_PLACEHOLDER\n#CONDA_ACTIVATION_PLACEHOLDER\n")
+        template_path = f.name
+
+    jobs_dir = tempfile.mkdtemp()
+
+    slurm_cfg = {"conda_env": "malicious_env; echo 'hacked'"}
+    command = "python script.py --arg 'malicious; rm -rf /'"
+    conda_env = "malicious_env; echo 'hacked'"
+
+    try:
+        script_path = update_slurm_script(template_path, command, slurm_cfg, jobs_dir, conda_env)
+
+        with open(script_path, "r") as f:
+            content = f.read()
+
+        # The variables should be quoted so they don't break out into their own commands
+        assert "srun conda run -n 'malicious_env; echo '\"'\"'hacked'\"'\"'' python script.py --arg 'malicious; rm -rf /'" in content, content
+        assert "conda activate 'malicious_env; echo '\"'\"'hacked'\"'\"''" in content, content
+
+    finally:
+        os.remove(template_path)
+        for file in os.listdir(jobs_dir):
+            os.remove(os.path.join(jobs_dir, file))
+        os.rmdir(jobs_dir)


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in `src/utils/slurm.py` where untrusted configuration and command strings were placed unescaped directly into a generated SLURM `.sh` template file.

⚠️ **Risk:** Critical. If left unfixed, an attacker or user providing malicious input for a config like `conda_env` (or arguments containing shell metacharacters such as `;"`, `&`, `|`, etc.) could inject arbitrary bash commands that would be executed on the SLURM node when the script is run. This could lead to a complete compromise of the compute instance, data exfiltration, or denial of service.

🛡️ **Solution:** Updated the `update_slurm_script` function to employ `shlex.quote()`.
*   Sanitized `conda_env` configurations by using `shlex.quote()`.
*   Handled the `command` correctly by parsing it with `shlex.split()` and then securely quoting each constituent part with `shlex.quote()`.
*   Created a comprehensive test case in `tests/utils/test_slurm.py` simulating an attacker's payload `malicious; rm -rf /` to confirm the output script properly escapes it and maintains safety.

---
*PR created automatically by Jules for task [5118513559299004540](https://jules.google.com/task/5118513559299004540) started by @jonathanrppittman*