### PR TITLE
🔒 Fix command injection vulnerability in ProcessExecutor

### DIFF
--- a/src/utils/process_runner.py
+++ b/src/utils/process_runner.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import platform
+import shlex
 from typing import Optional, Iterator, Tuple
 from PyQt5.QtCore import QThread, pyqtSignal
 
@@ -22,9 +23,12 @@ class ProcessExecutor:
         """
         try:
             if platform.system() == "Windows":
-                command_list = ["cmd.exe", "/c", self.command]
+                # Parse Windows command string into list, keeping quotes intact initially to preserve paths
+                parsed_args = shlex.split(self.command, posix=False)
+                # Remove outermost quotes that shlex leaves behind for posix=False
+                command_list = [arg[1:-1] if arg.startswith('"') and arg.endswith('"') else arg for arg in parsed_args]
             else:
-                command_list = ["/usr/bin/bash", "-c", self.command]
+                command_list = shlex.split(self.command, posix=True)
 
             proc = subprocess.Popen(
                 command_list,

--- a/tests/utils/test_process_runner.py
+++ b/tests/utils/test_process_runner.py
@@ -21,7 +21,8 @@ def test_executor_success():
 
 def test_executor_failure():
     """Test that ProcessExecutor handles a failing command and captures the error code."""
-    command = '>&2 echo "An error occurred" && exit 123'
+    # We use python -c to simulate a failure and stderr output, instead of relying on shell operators like && and redirect
+    command = "python3 -c \"import sys; print('An error occurred', file=sys.stderr); sys.exit(123)\""
     executor = ProcessExecutor(command)
 
     output_lines = []
@@ -62,9 +63,14 @@ def test_executor_command_not_found():
         if code == -1:
             output_lines.append(line)
         else:
+            # If the process fails to start, the exception is yielded with exit code 1
+            if line:
+                output_lines.append(line)
             return_code = code
 
-    # The shell will output an error message
-    assert "command not found" in "".join(output_lines).lower()
-    # The exit code from the shell for command not found is typically 127
-    assert return_code == 127
+    # Without the shell, Popen itself will raise a FileNotFoundError
+    # which is caught and yielded as a string in our executor.
+    output_str = "".join(output_lines).lower()
+    assert "no such file or directory" in output_str or "not found" in output_str
+    # The exit code returned by our exception handler is 1
+    assert return_code == 1


### PR DESCRIPTION
🎯 **What:** The `ProcessExecutor` previously wrapped arbitrary command strings in `cmd.exe /c` (Windows) or `/usr/bin/bash -c` (POSIX) before passing them to `subprocess.Popen`. This allowed command injection because the string was evaluated by a shell.

⚠️ **Risk:** A malicious user or script could inject arbitrary shell commands, such as `&& rm -rf /` or starting unauthorized background processes. If an attacker had control over any part of the command string (e.g. paths, configurations), they could execute arbitrary code on the system.

🛡️ **Solution:** The fix parses the command string into a list of arguments directly using `shlex.split` and passes this list to `subprocess.Popen` without a shell. On POSIX, `shlex.split(command, posix=True)` is used. On Windows, `shlex.split(command, posix=False)` is used to properly parse but preserve backslashes, and then the outermost quotes on the tokens are stripped. Unit tests were also refactored to simulate failing commands using Python directly rather than relying on shell operators (like `&&`) which are no longer supported in the executor.

---
*PR created automatically by Jules for task [7972749991039717235](https://jules.google.com/task/7972749991039717235) started by @jonathanrppittman*